### PR TITLE
Complete automation quality milestone

### DIFF
--- a/docs/plans/2026-03-12-automation-quality-and-testing-ergonomics-plan.md
+++ b/docs/plans/2026-03-12-automation-quality-and-testing-ergonomics-plan.md
@@ -1,0 +1,127 @@
+# Automation Quality and Testing Ergonomics Plan
+
+## Goal
+
+Improve Avalonia AutomationBridge so real app automation is more deterministic, cheaper to drive, and easier for app teams to author correctly.
+
+## Non-goals
+
+- Rework consumer apps in this milestone.
+- Remove or weaken existing bridge behavior to simplify implementation.
+- Introduce app-specific shortcuts or hardcoded selectors.
+
+## Acceptance Criteria
+
+- Queries can target higher-value UI state directly and can project only the requested fields.
+- Node summaries and deltas expose more explicit automation-relevant state without bloating default responses.
+- Action responses communicate observable completion more deterministically for same-node and closely related state changes.
+- CLI workflows support low-friction automation-id-first inspection and waiting flows.
+- Avalonia app authors have explicit guidance for bridge-friendly automation surfaces.
+- Automated tests cover protocol, selection, snapshot, action, and CLI behavior changes.
+
+## Relevant Code Surface
+
+- `src/Avalonia.AutomationBridge.Protocol/Messages/SelectorDto.cs`
+- `src/Avalonia.AutomationBridge.Protocol/Messages/NodeSummaryDto.cs`
+- `src/Avalonia.AutomationBridge.Protocol/Messages/BridgeRequest.cs`
+- `src/Avalonia.AutomationBridge.Protocol/Messages/DeltaDto.cs`
+- `src/Avalonia.Diagnostics.AutomationBridge/Selection/AutomationSelectorEvaluator.cs`
+- `src/Avalonia.Diagnostics.AutomationBridge/Snapshot/AutomationNodeSummaryBuilder.cs`
+- `src/Avalonia.Diagnostics.AutomationBridge/Snapshot/AutomationDeltaBuilder.cs`
+- `src/Avalonia.Diagnostics.AutomationBridge/Actions/AutomationActionDispatcher.cs`
+- `src/Avalonia.Diagnostics.AutomationBridge/Transport/AutomationBridgeRequestDispatcher.cs`
+- `src/tools/Avalonia.AutomationBridge.Cli/AutomationBridgeCliRunner.cs`
+- `tests/Avalonia.Diagnostics.AutomationBridge.Tests/Selection/SelectorTests.cs`
+- `tests/Avalonia.Diagnostics.AutomationBridge.Tests/Session/AutomationNodeSummaryBuilderTests.cs`
+- `tests/Avalonia.Diagnostics.AutomationBridge.Tests/Snapshot/DeltaTests.cs`
+- `tests/Avalonia.Diagnostics.AutomationBridge.Tests/Actions/ActionDispatchTests.cs`
+- `tests/Avalonia.Diagnostics.AutomationBridge.Tests/Cli/AutomationBridgeCliTests.cs`
+
+## Risks and Tradeoffs
+
+- Adding state fields without projection controls would increase response size and token cost.
+- Changing naming behavior too aggressively could break consumers depending on current labels.
+- Action completion semantics must remain honest; fake “completed” responses without observable state change would make the bridge less trustworthy.
+- CLI ergonomics depend on protocol shape, so issue ordering matters.
+
+## Task List
+
+### Task 1: Add selector filters and field projection
+
+- **Issue:** `#16`
+- **Objective:** Make queries target automation-relevant state precisely and return only requested fields.
+- **Files:**
+  - `src/Avalonia.AutomationBridge.Protocol/Messages/SelectorDto.cs`
+  - `src/Avalonia.AutomationBridge.Protocol/Messages/BridgeRequest.cs`
+  - `src/Avalonia.Diagnostics.AutomationBridge/Selection/AutomationSelectorEvaluator.cs`
+  - `src/Avalonia.Diagnostics.AutomationBridge/Transport/AutomationBridgeRequestDispatcher.cs`
+  - `tests/Avalonia.Diagnostics.AutomationBridge.Tests/Selection/SelectorTests.cs`
+  - `tests/Avalonia.Diagnostics.AutomationBridge.Tests/Transport/RequestDispatcherTests.cs`
+- **Tests:** Add or update tests first for `selected`, `offscreen`, and action-capability filtering plus requested-field projection behavior.
+- **Commands:**
+  - `dotnet test --project tests/Avalonia.Diagnostics.AutomationBridge.Tests/Avalonia.Diagnostics.AutomationBridge.Tests.csproj -v minimal -- --filter-class Avalonia.Diagnostics.AutomationBridge.Tests.Selection.SelectorTests`
+  - `dotnet test --project tests/Avalonia.Diagnostics.AutomationBridge.Tests/Avalonia.Diagnostics.AutomationBridge.Tests.csproj -v minimal -- --filter-class Avalonia.Diagnostics.AutomationBridge.Tests.Transport.RequestDispatcherTests`
+
+### Task 2: Expand summary and delta state semantics
+
+- **Issue:** `#17`
+- **Objective:** Expose explicit UI state that removes ambiguity without forcing broad re-queries.
+- **Files:**
+  - `src/Avalonia.AutomationBridge.Protocol/Messages/NodeSummaryDto.cs`
+  - `src/Avalonia.AutomationBridge.Protocol/Messages/DeltaDto.cs`
+  - `src/Avalonia.Diagnostics.AutomationBridge/Snapshot/AutomationNodeSummaryBuilder.cs`
+  - `src/Avalonia.Diagnostics.AutomationBridge/Snapshot/AutomationDeltaBuilder.cs`
+  - `tests/Avalonia.Diagnostics.AutomationBridge.Tests/Session/AutomationNodeSummaryBuilderTests.cs`
+  - `tests/Avalonia.Diagnostics.AutomationBridge.Tests/Snapshot/DeltaTests.cs`
+  - `tests/Avalonia.Diagnostics.AutomationBridge.Tests/Protocol/NodeSummarySerializationTests.cs`
+  - `tests/Avalonia.Diagnostics.AutomationBridge.Tests/Protocol/DeltaSerializationTests.cs`
+- **Tests:** Add or update tests first for selected, expanded, checked, state, and metadata projection/serialization.
+- **Commands:**
+  - `dotnet test --project tests/Avalonia.Diagnostics.AutomationBridge.Tests/Avalonia.Diagnostics.AutomationBridge.Tests.csproj -v minimal -- --filter-class Avalonia.Diagnostics.AutomationBridge.Tests.Session.AutomationNodeSummaryBuilderTests`
+  - `dotnet test --project tests/Avalonia.Diagnostics.AutomationBridge.Tests/Avalonia.Diagnostics.AutomationBridge.Tests.csproj -v minimal -- --filter-class Avalonia.Diagnostics.AutomationBridge.Tests.Snapshot.DeltaTests`
+
+### Task 3: Strengthen action completion semantics
+
+- **Issue:** `#18`
+- **Objective:** Make action responses reflect observable completion for same-node and related-node changes without overstating success.
+- **Files:**
+  - `src/Avalonia.Diagnostics.AutomationBridge/Actions/AutomationActionDispatcher.cs`
+  - `src/Avalonia.Diagnostics.AutomationBridge/Snapshot/AutomationDeltaBuilder.cs`
+  - `tests/Avalonia.Diagnostics.AutomationBridge.Tests/Actions/ActionDispatchTests.cs`
+- **Tests:** Add or update tests first for related-node change detection, no-change outcomes, and preservation of event-driven completion behavior.
+- **Commands:**
+  - `dotnet test --project tests/Avalonia.Diagnostics.AutomationBridge.Tests/Avalonia.Diagnostics.AutomationBridge.Tests.csproj -v minimal -- --filter-class Avalonia.Diagnostics.AutomationBridge.Tests.Actions.ActionDispatchTests`
+
+### Task 4: Improve CLI targeting and synchronization
+
+- **Issue:** `#19`
+- **Objective:** Make the CLI efficient for both humans and agents on top of the stronger protocol/query surface.
+- **Files:**
+  - `src/tools/Avalonia.AutomationBridge.Cli/AutomationBridgeCliRunner.cs`
+  - `src/tools/Avalonia.AutomationBridge.Cli/Program.cs`
+  - `tests/Avalonia.Diagnostics.AutomationBridge.Tests/Cli/AutomationBridgeCliTests.cs`
+- **Tests:** Add or update tests first for automation-id-first commands, field projection, inspection helpers, and `wait-for` behavior.
+- **Commands:**
+  - `dotnet test --project tests/Avalonia.Diagnostics.AutomationBridge.Tests/Avalonia.Diagnostics.AutomationBridge.Tests.csproj -v minimal -- --filter-class Avalonia.Diagnostics.AutomationBridge.Tests.Cli.AutomationBridgeCliTests`
+
+### Task 5: Document bridge-friendly app authoring conventions
+
+- **Issue:** `#20`
+- **Objective:** Give app teams a stable contract for exposing automation surfaces that work well with the bridge.
+- **Files:**
+  - `src/Avalonia.Diagnostics.AutomationBridge/README.md` or a new bridge-specific guidance doc under `docs/`
+  - any nearby examples/tests updated to reflect the conventions
+- **Tests:** Add or update example-oriented tests only where they enforce real bridge behavior, not documentation wording.
+- **Commands:**
+  - `dotnet test --project tests/Avalonia.Diagnostics.AutomationBridge.Tests/Avalonia.Diagnostics.AutomationBridge.Tests.csproj -v minimal`
+
+## Final Verification Checklist
+
+- `dotnet test --project tests/Avalonia.Diagnostics.AutomationBridge.Tests/Avalonia.Diagnostics.AutomationBridge.Tests.csproj -v minimal`
+- `dotnet build src/Avalonia.Diagnostics.AutomationBridge/Avalonia.Diagnostics.AutomationBridge.csproj -warnaserror`
+- `dotnet build src/tools/Avalonia.AutomationBridge.Cli/Avalonia.AutomationBridge.Cli.csproj -warnaserror`
+- Fresh manual validation against a consumer app using targeted queries and actions:
+  - automation-id-first query
+  - selected-state query
+  - action with immediate completion evidence
+  - CLI wait/inspect flow

--- a/src/Avalonia.Diagnostics.AutomationBridge/Actions/AutomationActionDispatcher.cs
+++ b/src/Avalonia.Diagnostics.AutomationBridge/Actions/AutomationActionDispatcher.cs
@@ -38,6 +38,7 @@ public static class AutomationActionDispatcher
             var deltaBuilder = session.GetOrCreateDeltaBuilderForPeer(peer);
             var startingRevision = deltaBuilder.CurrentRevision;
             deltaBuilder.BeginActionCapture(startingRevision);
+            var beforeActionSummary = session.SummarizePeer(peer);
 
             var response = request.Action switch
             {
@@ -61,6 +62,9 @@ public static class AutomationActionDispatcher
             }
 
             var delta = deltaBuilder.CompleteAction(peer, startingRevision);
+            if (delta.Revision == startingRevision)
+                delta = deltaBuilder.ReconcileActionState(peer, beforeActionSummary);
+
             var completionState = delta.Revision == startingRevision
                 ? BridgeActionCompletionState.Accepted
                 : BridgeActionCompletionState.Completed;

--- a/src/Avalonia.Diagnostics.AutomationBridge/Snapshot/AutomationDeltaBuilder.cs
+++ b/src/Avalonia.Diagnostics.AutomationBridge/Snapshot/AutomationDeltaBuilder.cs
@@ -99,6 +99,17 @@ internal sealed class AutomationDeltaBuilder : IDisposable
         }
     }
 
+    public DeltaDto ReconcileActionState(AutomationPeer peer, NodeSummaryDto beforeActionSummary)
+    {
+        ArgumentNullException.ThrowIfNull(peer);
+        ArgumentNullException.ThrowIfNull(beforeActionSummary);
+
+        var patch = BuildReconciledPatch(peer, beforeActionSummary);
+        return patch is null
+            ? EmptyDelta(_revision)
+            : PublishDelta([patch], Array.Empty<string>(), Array.Empty<string>(), null);
+    }
+
     public void EndActionCapture()
     {
         _capturedStartingRevision = null;
@@ -401,6 +412,52 @@ internal sealed class AutomationDeltaBuilder : IDisposable
         };
     }
 
+    private NodePatchDto? BuildReconciledPatch(AutomationPeer peer, NodeSummaryDto beforeActionSummary)
+    {
+        var afterActionSummary = _session.SummarizePeer(peer);
+        var changed = false;
+
+        var enabled = TryGetChangedValue(beforeActionSummary.Enabled, afterActionSummary.Enabled, ref changed);
+        var focused = TryGetChangedValue(beforeActionSummary.Focused, afterActionSummary.Focused, ref changed);
+        var value = TryGetChangedValue(beforeActionSummary.Value, afterActionSummary.Value, ref changed);
+        var offscreen = TryGetChangedValue(beforeActionSummary.Offscreen, afterActionSummary.Offscreen, ref changed);
+        var selected = TryGetChangedValue(beforeActionSummary.Selected, afterActionSummary.Selected, ref changed);
+        var expanded = TryGetChangedValue(beforeActionSummary.Expanded, afterActionSummary.Expanded, ref changed);
+        var checkedState = TryGetChangedValue(beforeActionSummary.Checked, afterActionSummary.Checked, ref changed);
+        var name = TryGetChangedValue(beforeActionSummary.Name, afterActionSummary.Name, ref changed);
+        var state = TryGetChangedMap(beforeActionSummary.State, afterActionSummary.State, ref changed);
+        var metadata = TryGetChangedMap(beforeActionSummary.Metadata, afterActionSummary.Metadata, ref changed);
+
+        if (!changed)
+            return null;
+
+        return new NodePatchDto
+        {
+            Id = afterActionSummary.Id,
+            Enabled = enabled,
+            Focused = focused,
+            Value = value,
+            Offscreen = offscreen,
+            Selected = selected,
+            Expanded = expanded,
+            Checked = checkedState,
+            Name = name,
+            State = state,
+            Metadata = metadata,
+            Cleared = BuildClearedFields(
+                (NodePatchField.Enabled, beforeActionSummary.Enabled is not null && afterActionSummary.Enabled is null),
+                (NodePatchField.Focused, beforeActionSummary.Focused is not null && afterActionSummary.Focused is null),
+                (NodePatchField.Value, beforeActionSummary.Value is not null && afterActionSummary.Value is null),
+                (NodePatchField.Offscreen, beforeActionSummary.Offscreen is not null && afterActionSummary.Offscreen is null),
+                (NodePatchField.Selected, beforeActionSummary.Selected is not null && afterActionSummary.Selected is null),
+                (NodePatchField.Expanded, beforeActionSummary.Expanded is not null && afterActionSummary.Expanded is null),
+                (NodePatchField.Checked, beforeActionSummary.Checked is not null && afterActionSummary.Checked is null),
+                (NodePatchField.Name, beforeActionSummary.Name is not null && afterActionSummary.Name is null),
+                (NodePatchField.State, beforeActionSummary.State is not null && afterActionSummary.State is null),
+                (NodePatchField.Metadata, beforeActionSummary.Metadata is not null && afterActionSummary.Metadata is null)),
+        };
+    }
+
     private NodePatchDto? BuildPatch(AutomationPeer peer, AutomationProperty property)
     {
         var id = _session.GetOrAssignHandle(peer);
@@ -506,6 +563,61 @@ internal sealed class AutomationDeltaBuilder : IDisposable
 
         cleared ??= [];
         cleared.Add(field);
+    }
+
+    private static bool? TryGetChangedValue(bool? before, bool? after, ref bool changed)
+    {
+        if (before == after)
+            return null;
+
+        changed = true;
+        return after;
+    }
+
+    private static string? TryGetChangedValue(string? before, string? after, ref bool changed)
+    {
+        if (string.Equals(before, after, StringComparison.Ordinal))
+            return null;
+
+        changed = true;
+        return after;
+    }
+
+    private static IReadOnlyDictionary<string, string>? TryGetChangedMap(
+        IReadOnlyDictionary<string, string>? before,
+        IReadOnlyDictionary<string, string>? after,
+        ref bool changed)
+    {
+        if (AreEquivalent(before, after))
+            return null;
+
+        changed = true;
+        return after;
+    }
+
+    private static bool AreEquivalent(
+        IReadOnlyDictionary<string, string>? before,
+        IReadOnlyDictionary<string, string>? after)
+    {
+        if (ReferenceEquals(before, after))
+            return true;
+
+        if (before is null || after is null)
+            return before is null && after is null;
+
+        if (before.Count != after.Count)
+            return false;
+
+        foreach (var (key, value) in before)
+        {
+            if (!after.TryGetValue(key, out var afterValue)
+                || !string.Equals(value, afterValue, StringComparison.Ordinal))
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private static IEnumerable<AutomationPeer> EnumerateSubtree(AutomationPeer root)

--- a/tests/Avalonia.Diagnostics.AutomationBridge.Tests/Actions/ActionDispatchTests.cs
+++ b/tests/Avalonia.Diagnostics.AutomationBridge.Tests/Actions/ActionDispatchTests.cs
@@ -262,6 +262,39 @@ public sealed class ActionDispatchTests
     }
 
     [Fact]
+    public void Dispatch_ReturnsCompletedCompletion_WhenActionPublishesRelatedNodeModalState()
+    {
+        var root = new StubAutomationPeer { ControlType = Avalonia.Automation.Peers.AutomationControlType.Window };
+        var target = new StubAutomationPeer();
+        var related = new StubAutomationPeer { Name = "Dialog Host" };
+        target.RegisterProvider<IInvokeProvider>(new RelatedNodeModalInvokeProvider(related));
+        root.AddChild(target);
+        root.AddChild(related);
+
+        using var session = new AutomationBridgeSession(new AutomationRootRegistry(() => new[] { root }));
+        _ = session.GetRoots();
+        var targetId = session.GetOrAssignHandle(target);
+        var relatedId = session.GetOrAssignHandle(related);
+
+        var response = AutomationActionDispatcher.Dispatch(
+            session,
+            new BridgeRequest
+            {
+                Action = BridgeAction.Invoke,
+                NodeId = targetId,
+            });
+
+        Assert.True(response.Ok);
+        Assert.Equal(BridgeActionCompletionState.Completed, response.Completion?.State);
+        Assert.NotNull(response.Delta);
+        var patch = Assert.Single(response.Delta!.Updated);
+        Assert.Equal(relatedId, patch.Id);
+        Assert.NotNull(patch.State);
+        Assert.Equal("true", patch.State!["busy"]);
+        Assert.Equal("true", patch.State["modal"]);
+    }
+
+    [Fact]
     public void Dispatch_AggregatesMultipleDeltaEvents_FromOneAction()
     {
         var peer = new StubAutomationPeer { Name = "Original" };
@@ -496,6 +529,25 @@ public sealed class ActionDispatchTests
 
         public void SetValue(string? value)
             => _peer.RaisePropertyChangedEvent(ValuePatternIdentifiers.ValueProperty, null, value);
+    }
+
+    private sealed class RelatedNodeModalInvokeProvider : IInvokeProvider
+    {
+        private readonly StubAutomationPeer _peer;
+
+        public RelatedNodeModalInvokeProvider(StubAutomationPeer peer)
+        {
+            _peer = peer;
+        }
+
+        public void Invoke()
+        {
+            _peer.ItemStatus = "busy; modal=true";
+            _peer.RaisePropertyChangedEvent(
+                AutomationElementIdentifiers.ItemStatusProperty,
+                null,
+                _peer.ItemStatus);
+        }
     }
 
     private sealed class MultiEventRaisingValueProvider : IValueProvider

--- a/tests/Avalonia.Diagnostics.AutomationBridge.Tests/Actions/ActionDispatchTests.cs
+++ b/tests/Avalonia.Diagnostics.AutomationBridge.Tests/Actions/ActionDispatchTests.cs
@@ -237,6 +237,31 @@ public sealed class ActionDispatchTests
     }
 
     [Fact]
+    public void Dispatch_ReturnsCompletedCompletion_WhenSelectMutatesStateWithoutAutomationEvent()
+    {
+        var peer = new StubAutomationPeer();
+        var provider = new MutableSelectionItemProvider();
+        peer.RegisterProvider<ISelectionItemProvider>(provider);
+        var fixture = CreateFixture(peer);
+
+        var response = AutomationActionDispatcher.Dispatch(
+            fixture.Session,
+            new BridgeRequest
+            {
+                Action = BridgeAction.Select,
+                NodeId = fixture.NodeId,
+            });
+
+        Assert.True(response.Ok);
+        Assert.Equal(BridgeActionCompletionState.Completed, response.Completion?.State);
+        Assert.NotNull(response.Delta);
+        var patch = Assert.Single(response.Delta!.Updated);
+        Assert.True(patch.Selected);
+        Assert.Empty(response.Delta.Added);
+        Assert.Empty(response.Delta.Removed);
+    }
+
+    [Fact]
     public void Dispatch_AggregatesMultipleDeltaEvents_FromOneAction()
     {
         var peer = new StubAutomationPeer { Name = "Original" };
@@ -546,6 +571,18 @@ public sealed class ActionDispatchTests
         public void RemoveFromSelection() { }
 
         public void Select() => throw new InvalidOperationException("selection exploded");
+    }
+
+    private sealed class MutableSelectionItemProvider : ISelectionItemProvider
+    {
+        public bool IsSelected { get; private set; }
+        public ISelectionProvider? SelectionContainer => null;
+
+        public void AddToSelection() => IsSelected = true;
+
+        public void RemoveFromSelection() => IsSelected = false;
+
+        public void Select() => IsSelected = true;
     }
 
     private sealed class StubExpandCollapseProvider : IExpandCollapseProvider


### PR DESCRIPTION
## Summary
- add the execution plan for the automation quality milestone
- reconcile post-action bridge state when provider mutations do not publish automation events
- add action-dispatch coverage for related-node modal state completion behavior

## Linked issues
- Closes #15
- Closes #16
- Closes #17
- Closes #18
- Closes #19
- Closes #20

## Verification
- `dotnet test --project tests/Avalonia.Diagnostics.AutomationBridge.Tests/Avalonia.Diagnostics.AutomationBridge.Tests.csproj -v minimal`
- `dotnet build src/Avalonia.Diagnostics.AutomationBridge/Avalonia.Diagnostics.AutomationBridge.csproj -warnaserror`
- `dotnet build src/tools/Avalonia.AutomationBridge.Cli/Avalonia.AutomationBridge.Cli.csproj -warnaserror`
